### PR TITLE
Fix sidebar toggle to only trigger on mobile

### DIFF
--- a/components/sidebar-item.tsx
+++ b/components/sidebar-item.tsx
@@ -29,9 +29,10 @@ const ICONS: Record<string, React.ComponentType> = {
 };
 
 const SidebarItem = ({ item, isLoggedIn, isAdmin }: SidebarItemProps) => {
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, isMobile } = useSidebar();
 
   const handleClick = () => {
+    if (!isMobile) return;
     toggleSidebar();
   };
 


### PR DESCRIPTION
Added a check for the isMobile flag in the SidebarItem component so that toggleSidebar is only called on mobile devices. This prevents unnecessary sidebar toggling on desktop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar toggle behavior to only activate on mobile devices, preventing unintended sidebar toggles on desktop.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->