### PR TITLE
Add SidebarTriggerWrapper to conditionally render trigger

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { cookies } from "next/headers";
 import Providers from "@/components/providers";
+import SidebarTriggerWrapper from "@/components/sidebar-trigger-wrapper";
 
 export default async function AppLayout({
   children,
@@ -21,10 +22,7 @@ export default async function AppLayout({
       <SidebarProvider defaultOpen={defaultOpen}>
         <AppSidebar />
         <main className="relative min-h-screen w-full">
-          <SidebarTrigger
-            className="fixed top-3 ml-2 z-[60] size-10 rounded-md bg-background border shadow-sm hover:bg-muted transition-colors duration-200"
-            aria-label="Toggle sidebar"
-          />
+          <SidebarTriggerWrapper />
           {children}
         </main>
       </SidebarProvider>

--- a/components/sidebar-trigger-wrapper.tsx
+++ b/components/sidebar-trigger-wrapper.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { SidebarTrigger, useSidebar } from "./ui/sidebar";
+
+const SidebarTriggerWrapper = () => {
+  const { openMobile, isMobile } = useSidebar();
+
+  if (isMobile && openMobile) return null;
+
+  return (
+    <SidebarTrigger
+      className="fixed top-3 ml-2 z-[60] size-10 rounded-md bg-background border shadow-sm hover:bg-muted transition-colors duration-200"
+      aria-label="Toggle sidebar"
+    />
+  );
+};
+
+export default SidebarTriggerWrapper;


### PR DESCRIPTION
Introduced a SidebarTriggerWrapper component that hides the sidebar trigger on mobile when the sidebar is open. Updated AppLayout to use this wrapper instead of rendering SidebarTrigger directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved sidebar trigger component structure with enhanced mobile sidebar state handling. The trigger now properly responds to mobile sidebar open/closed states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->